### PR TITLE
Add extension operation

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -44,6 +44,53 @@ macro_rules! tensor {
     ($x:ty , $i: expr, $($is:expr),+) => {[tensor!($x, $($is),+); $i]};
 }
 
+pub trait Extensible<A> {
+    fn apply<F>(&self, other: &Self, op: &F) -> Self
+    where
+        F: Fn(&A, &A) -> A;
+}
+
+impl<A, T, const N: usize> Extensible<A> for [T; N]
+where
+    T: Extensible<A> + Copy + Default,
+{
+    fn apply<F>(&self, other: &Self, op: &F) -> Self
+    where
+        F: Fn(&A, &A) -> A,
+    {
+        let mut result = [Default::default(); N];
+        for (i, coord) in self.iter().enumerate() {
+            result[i] = T::apply(coord, &other[i], op);
+        }
+        result
+    }
+}
+
+#[macro_export]
+macro_rules! extensible {
+    ($x: ty) => {
+        impl Extensible<$x> for $x {
+            fn apply<F>(&self, other: &Self, op: &F) -> Self
+            where
+                F: Fn(&Self, &Self) -> Self,
+            {
+                op(self, other)
+            }
+        }
+    };
+}
+
+extensible!(u8);
+extensible!(f64);
+
+pub fn extension<T, A, F>(t1: &T, t2: &T, op: F) -> T
+where
+    T: Extensible<A>,
+    F: Fn(&A, &A) -> A,
+{
+    t1.apply::<F>(t2, &op)
+}
+
 fn main() {
     let y = line(&[1.0, 7.3], &linear_params_2d(3.0, 1.0));
     println!("{:?}", y);
@@ -54,7 +101,22 @@ mod tests {
     use super::*;
 
     #[test]
-    fn test_tensor() {
+    fn test_tensor_type() {
         let _: tensor!(f64, 1, 2, 3) = [[[1.0, 3.0, 6.0], [-1.3, -30.0, -0.0]]];
+    }
+
+    #[test]
+    fn test_extension() {
+        let x: tensor!(u8, 1) = [2];
+        let y: tensor!(u8, 1) = [7];
+        assert_eq!(extension(&x, &y, |x, y| x + y), [9]);
+
+        let x: tensor!(u8, 3) = [5, 6, 7];
+        let y: tensor!(u8, 3) = [2, 0, 1];
+        assert_eq!(extension(&x, &y, |x, y| x + y), [7, 6, 8]);
+
+        let x: tensor!(u8, 2, 3) = [[4, 6, 7], [2, 0, 1]];
+        let y: tensor!(u8, 2, 3) = [[1, 2, 2], [6, 3, 1]];
+        assert_eq!(extension(&x, &y, |x, y| x + y), [[5, 8, 9], [8, 3, 2]]);
     }
 }


### PR DESCRIPTION
In the vocabulary of _The Little Learner_, the *extension* of operation `op: A -> B -> C` over two tensors with element types `A` and `B` respectively (and of the same shape) is simply the tensor created by `op`-ing the respective elements of the input tensors. That is, `extension(op)` is of type `tensor!(A, shape) -> tensor!(B, shape) -> tensor!(C, shape)`.

Because we don't appear to have rank-2 polymorphism, I restricted to the case where `A = B = C`, so that we could reuse the types rather than somehow conjuring up `tensor!(C, shape)`.

Is this *totally* insane? It's certainly sad that I have to write `extensible!(base_type)` for every `base_type` I want to be able to `extension` over.